### PR TITLE
By default Localstack IAM service is listen 4593 port

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class LocalstackPlugin {
       'sns': 4575,
       'sqs': 4576,
       'sts': 4592,
-      'iam': 4592
+      'iam': 4593
     };
 
     // Intercept Provider requests


### PR DESCRIPTION
When deploy local serverless project, then IAM service pointing to the same STS port.