### PR TITLE
Localize use of dummy credentials

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,14 +225,6 @@ class LocalstackPlugin {
   }
 
   /**
-   * Configure dummy AWS credentials in the environment, to ensure the AWS client libs don't bail.
-   */
-  configureAWSCredentials() {
-    process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'test';
-    process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'test';
-  }
-
-  /**
    * Create custom Serverless deployment bucket, if one is configured.
    */
   createDeploymentBucket() {
@@ -261,8 +253,13 @@ class LocalstackPlugin {
       const host = this.config.host;
       const configChanges = {};
 
-      // make sure we have AWS credentials configured
-      this.configureAWSCredentials();
+      // Configure dummy AWS credentials in the environment, to ensure the AWS client libs don't bail.
+      if (!process.env.AWS_SECRET_ACCESS_KEY){
+        const accessKeyId = process.env.AWS_ACCESS_KEY_ID || 'test';
+        const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY || 'test';
+        const fakeCredentials = new AWS.Credentials({accessKeyId, secretAccessKey})
+        configChanges.credentials = fakeCredentials;
+      }
 
       // If a host has been configured, override each service
       if (host) {


### PR DESCRIPTION
This is an attempt to fix https://github.com/localstack/serverless-localstack/issues/19

serverless-localstack should not change the AWS credentials environment variables, as they will override the credentials configured by serverless.yml.

A better approach is to set the credentials directly when updating the AWS config.

I have verified that this fixes #19, but I cannot verify that it did not break the feature added in https://github.com/localstack/serverless-localstack/pull/13 since that pull request did not include any tests.