### PR TITLE
Give a user friendly message if plugin is listed but not activated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ class LocalstackPlugin {
     this.readConfig();
 
     if (!this.isActive()) {
+      this.log("serverless-localstack plugin not activated. '"
+        + (this.options.stage || defaultStage) + "' is not present in config custom.localstack.stages");
       return;
     }
 


### PR DESCRIPTION
Having tripped over this one I thought it good to help others not do the same.

It's obvious after the fact, but seeing that localstack.stages doesn't contain local was not obvious due in the following snippet, so the localstack plugin was silently doing nothing despite `--stage local` being specified.
```
custom:
  localstack:
    debug: true
    host: http://localhost
    lambda:
      # Enable this flag to improve performance
      mountCode: True
  stages:
    - local
    - dev
    - staging
    - production
```
You could actually go further and abort for misconfiguration if localstack.stages is missing or empty, as without those it's pointless having the plugin in the list. 

Perhaps that hard-fail would make more sense.  i.e. the following should error:

```
plugins:
  - serverless-localstack
custom:
  localstack:
    host: http://localhost
```
but this would be okay
```
plugins:
  - serverless-localstack
custom:
  localstack:
    stages:
      - local
    host: http://localhost
```
