### PR TITLE
Allow customizing $DOCKER_FLAGS; add endpoint for SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ custom:
 
 ## Change Log
 
+* v0.4.13: Add endpoint for SSM; patch serverless-secrets plugin; allow customizing $DOCKER_FLAGS
 * v0.4.12: Fix Lambda packaging for `mountCode:false`
 * v0.4.11: Add polling loop for starting LocalStack in Docker
 * v0.4.8: Auto-create deployment bucket; autostart LocalStack in Docker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
* allow customizing $DOCKER_FLAGS
* add endpoint for SSM
* patch serverless-secrets plugin to use local endpoints, if necessary
* patch S3 getBucketLocation invocation responses
* release new version