### PR TITLE
Initialize LocalStack using hooks for each "before:" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ custom:
 
 ## Change Log
 
+* v0.4.14: Initialize LocalStack using hooks for each "before:" event
 * v0.4.13: Add endpoint for SSM; patch serverless-secrets plugin; allow customizing $DOCKER_FLAGS
 * v0.4.12: Fix Lambda packaging for `mountCode:false`
 * v0.4.11: Add polling loop for starting LocalStack in Docker

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Initialize LocalStack using hooks for each `before:` event

This is a follow-up PR for #24. The problem with #24 is that it introduced an async call directly in the constructor of the plugin, which resulted in the situation that the plugin wasn't fully initialized once the lifecycle stages started executing.

In particular, the Docker container is still not fully initialized when Serverless gets to the `deploy` stage, which causes the plugin to fail with an error.

The async initialization code is now moved out of the constructor and into the `beforeEventHook(..)` method, and this method is enabled for each event type whose name starts with `before:`.