### PR TITLE
support variables in config localstack: block

### DIFF
--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -51,6 +51,7 @@ describe("LocalstackPlugin", () => {
 
   let simulateBeforeDeployHooks = function(instance){
     instance.readConfig();
+    instance.activatePlugin();
     instance.getStageVariable()
     instance.reconfigureAWS()
   }
@@ -181,6 +182,8 @@ describe("LocalstackPlugin", () => {
     it('should not send validateTemplate calls to localstack', () => {
       const request = sinon.stub(awsProvider, 'request');
       instance = new LocalstackPlugin(serverless, defaultPluginState)
+      simulateBeforeDeployHooks(instance);
+
       awsProvider.request('S3', 'validateTemplate', {});
 
       expect(request.called).to.be.false;

--- a/src/index.js
+++ b/src/index.js
@@ -56,22 +56,7 @@ class LocalstackPlugin {
 
   }
 
-  beforeEventHook() {
-    this.readConfig();
-    if (!this.isActive()) {
-      return Promise.resolve();
-    }
-    if (this.pluginEnabled) {
-      return Promise.resolve();
-    }
-    this.pluginEnabled = true;
-    return this.enablePlugin();
-  }
-
-  enablePlugin() {
-    // reconfigure AWS endpoints based on current stage variables
-    this.getStageVariable();
-
+  activatePlugin() {
     // Intercept Provider requests
     this.awsProvider = this.serverless.getProvider('aws');
     this.awsProviderRequest = this.awsProvider.request.bind(this.awsProvider);
@@ -112,6 +97,24 @@ class LocalstackPlugin {
     this.skipIfMountLambda('AwsCompileFunctions', 'downloadPackageArtifacts');
     this.skipIfMountLambda('AwsDeploy', 'extendedValidate');
     this.skipIfMountLambda('AwsDeploy', 'uploadFunctionsAndLayers');
+  }
+
+  beforeEventHook() {
+    this.readConfig();
+    if (!this.isActive()) {
+      return Promise.resolve();
+    }
+    this.activatePlugin();
+    if (this.pluginEnabled) {
+      return Promise.resolve();
+    }
+    this.pluginEnabled = true;
+    return this.enablePlugin();
+  }
+
+  enablePlugin() {
+    // reconfigure AWS endpoints based on current stage variables
+    this.getStageVariable();
 
     return this.startLocalStack().then(
       () => {

--- a/src/index.js
+++ b/src/index.js
@@ -156,8 +156,8 @@ class LocalstackPlugin {
   }
 
   readConfig() {
-    this.config = (this.serverless.service.custom || {}).localstack || {};
-    Object.assign({}, this.options, this.config);
+    const localstackConfig = (this.serverless.service.custom || {}).localstack || {};
+    this.config = Object.assign({}, this.options, localstackConfig);
 
     //Get the target deployment stage
     this.config.stage = "";

--- a/src/index.js
+++ b/src/index.js
@@ -100,14 +100,16 @@ class LocalstackPlugin {
   }
 
   beforeEventHook() {
+    if (this.pluginEnabled) {
+      return Promise.resolve();
+    }
+
     this.readConfig();
     if (!this.isActive()) {
       return Promise.resolve();
     }
     this.activatePlugin();
-    if (this.pluginEnabled) {
-      return Promise.resolve();
-    }
+
     this.pluginEnabled = true;
     return this.enablePlugin();
   }


### PR DESCRIPTION
Support variables in `localstack:` config block by calling `readConfig()` (and anything that depends on `readConfig()` during/after event hooks.

Fixes #40 