### PR TITLE
fix output of API endpoints if plugin is not activated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,9 @@ class LocalstackPlugin {
   }
 
   fixOutputEndpoints() {
+    if(!this.isActive()) {
+      return;
+    }
     const plugin = this.findPlugin('AwsInfo');
     const endpoints = plugin.gatheredData.info.endpoints || [];
     endpoints.forEach((entry, idx) => {


### PR DESCRIPTION
Fix output of API endpoints if plugin is not activated - fixes #63