### PR TITLE
Enable SSM and CF output refs by performing early plugin loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
   - npm run test
   # setup links for integration testing
   - npm link
-  # Kick off integration test
+  # kick off integration test
   - sleep 5; SLS_DEBUG=1 npm run test:integration

--- a/example/service/serverless.yml
+++ b/example/service/serverless.yml
@@ -15,5 +15,8 @@ custom:
 functions:
   hello:
     handler: handler.hello
+    environment:
+      SSM_VAR: ${ssm:abc}
+      # CF_VAR: ${cf:def}
     events:
       - sns: ${env:EXISTING_TOPIC_ARN}

--- a/spec/helpers/services.js
+++ b/spec/helpers/services.js
@@ -71,6 +71,5 @@ exports.deployService = (dir) => {
 }
 
 exports.removeService = (dir) => {
-  // execServerless('remove', dir);
   rimraf.sync(dir)
 }

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -8,11 +8,11 @@ describe('LocalstackPlugin', () => {
 
   beforeEach( () => {
     this.service = services.createService({});
-  })
+  });
 
   afterEach( () => {
     services.removeService(this.service);
-  })
+  });
 
   it('should deploy a stack', () => {
     services.deployService(this.service);


### PR DESCRIPTION
Enable SSM and CF output refs by performing early plugin loading - addresses #65