### PR TITLE
Locate container in case of a local build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -282,7 +282,7 @@ class LocalstackPlugin {
     const getContainer = () => {
       return exec('docker ps').then(
         (stdout) => {
-          const exists = stdout.split('\n').filter((line) => line.indexOf('localstack/localstack') >= 0);
+          const exists = stdout.split('\n').filter((line) => line.indexOf('localstack/localstack') >= 0 || line.indexOf('localstack_localstack') >= 0);
           if (exists.length) {
             return exists[0].replace('\t', ' ').split(' ')[0];
           }


### PR DESCRIPTION
In a case of a local build (`build: .` instead of `image: localstack/localstack` in docker-compose.yml) container name is `localstack_localstack`, not `localstack/localstack` and the plugin is not working.