### PR TITLE
sls deploy with localstack using docker autostart may fail and not return error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@ class LocalstackPlugin {
         env.LAMBDA_REMOTE_DOCKER = env.LAMBDA_REMOTE_DOCKER || '0';
         env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`;
         env.START_WEB = env.START_WEB || '0';
-        const maxBuffer = env.EXEC_MAXBUFFER||15*1000*1000; // 15mb buffer to handle output
+        const maxBuffer = (+env.EXEC_MAXBUFFER)||50*1000*1000; // 50mb buffer to handle output
         if (this.shouldRunDockerSudo()) {
           env.DOCKER_CMD = 'sudo docker';
         }

--- a/src/index.js
+++ b/src/index.js
@@ -325,10 +325,11 @@ class LocalstackPlugin {
         env.LAMBDA_REMOTE_DOCKER = env.LAMBDA_REMOTE_DOCKER || '0';
         env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`;
         env.START_WEB = env.START_WEB || '0';
+        const maxBuffer = env.EXEC_MAXBUFFER||15*1000*1000; // 15mb buffer to handle output
         if (this.shouldRunDockerSudo()) {
           env.DOCKER_CMD = 'sudo docker';
         }
-        const options = {env: env, maxBuffer: 15*1000*1000}; // 15mb buffer to handle output
+        const options = {env: env, maxBuffer};
         return exec('localstack infra start --docker', options).then(getContainer)
           .then((containerID) => checkStatus(containerID)
         );

--- a/src/index.js
+++ b/src/index.js
@@ -328,7 +328,7 @@ class LocalstackPlugin {
         if (this.shouldRunDockerSudo()) {
           env.DOCKER_CMD = 'sudo docker';
         }
-        const options = {env: env};
+        const options = {env: env, maxBuffer: 15*1000*1000}; // 15mb buffer to handle output
         return exec('localstack infra start --docker', options).then(getContainer)
           .then((containerID) => checkStatus(containerID)
         );


### PR DESCRIPTION
added maxbuffer to exec for localstack infra start so that can see error when bigger than nodejs default maxbuffer in exec.
Added also EXEC_MAXBUFFER to make it settable from env.