### PR TITLE
Not attempting to load the `endpointFile` if the plugin stage is not active.

### DIFF
--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -114,17 +114,32 @@ describe("LocalstackPlugin", () => {
         expect(plugin.endpoints).to.deep.equal(endpoints);
       });
 
-      it('should fail if the endpoint file does not exist', () => {
+      it('should fail if the endpoint file does not exist and the stages config option includes the deployment stage', () => {
         serverless.service.custom.localstack = {
-          endpointFile: 'missing.json'
+          endpointFile: 'missing.json',
+          stages: ['production']
         }
 
         let plugin = () => {
-          let pluginInstance = new LocalstackPlugin(serverless, defaultPluginState);
+          let pluginInstance = new LocalstackPlugin(serverless, {'stage':'production'});
           pluginInstance.readConfig();
         }
 
         expect(plugin).to.throw('Endpoint file "missing.json" is invalid:')
+      });
+
+      it('should not fail if the endpoint file does not exist when the stages config option does not include the deployment stage', () => {
+        serverless.service.custom.localstack = {
+          endpointFile: 'missing.json',
+          stages: ['production']
+        }
+
+        let plugin = () => {
+          let pluginInstance = new LocalstackPlugin(serverless, {'stage':'staging'});
+          pluginInstance.readConfig();
+        }
+
+        expect(plugin).to.not.throw('Endpoint file "missing.json" is invalid:')
       });
 
       it('should fail if the endpoint file is not json', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ class LocalstackPlugin {
     // To keep default behavior if config.stages is undefined, then use serverless-localstack-plugin
     this.endpoints = this.endpoints || this.config.endpoints || {};
     this.endpointFile = this.config.endpointFile;
-    if (this.endpointFile && !this._endpointFileLoaded) {
+    if (this.endpointFile && !this._endpointFileLoaded && this.isActive()) {
       try {
         this.loadEndpointsFromDisk(this.endpointFile);
         this._endpointFileLoaded = true;


### PR DESCRIPTION
This change results in the plugin _not_ attempting to load the `endpointFile` if the active stage is not one of the stages configured.

### Use case:
I'm trying to develop against a pool of Localstack containers, each bound to different ports. When deploying with Serverless I therefore need control over the ports. Unfortunately I am unable to use an environment variable to set `edgePort`:

```yaml
localstack:
    edgePort: ${env:LOCALSTACK_EDGE_PORT, '4566'}
    stages:
      - local
```
If I do, deployment fails and the following logs are produced:

```
Serverless: Reconfiguring service apigateway to use http://localhost:${env:LOCALSTACK_EDGE_PORT, '4566'}
Serverless: Reconfiguring service cloudformation to use http://localhost:${env:LOCALSTACK_EDGE_PORT, '4566'}
Serverless: Reconfiguring service cloudwatch to use http://localhost:${env:LOCALSTACK_EDGE_PORT, '4566'}
...
Serverless: Using custom endpoint for CloudFormation: http://localhost:${env:LOCALSTACK_EDGE_PORT, '4566'}
Serverless: Recoverable error occurred (connect ECONNREFUSED 127.0.0.1:80), sleeping for ~4 seconds. Try 1 of 4
Serverless: Recoverable error occurred (connect ECONNREFUSED 127.0.0.1:80), sleeping for ~4 seconds. Try 2 of 4
```

### Workaround:
Prior to deploying I instead dynamically generate an endpoint configuration file, pointing all the services I care about to the relevant Localstack edge port. Since this file is re-generated every time I run a test, I don't want to add it to source control.

However, as soon as I try to deploy from an environment that doesn't depend on Localstack, and hasn't generated the `endpointFile`, deployment fails with the following error:

```ReferenceError: Endpoint file "localstack-endpoint.json" is invalid: Error: ENOENT: no such file or directory, open 'localstack-endpoint.json'```

For the time being I've created a placeholder json file to use for deployments from such environments, but it seems that the plugin shouldn't need to load this file in the first place if it wasn't configured for the given stage.

### Versions:
`serverless`: `1.66.0`
`serverless-localstack`:`0.4.27`