### PR TITLE
replace display function for Step Functions Plug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -604,8 +604,7 @@ class LocalstackPlugin {
   stepFunctionsReplaceDisplay() {
     const plugin = this.findPlugin('ServerlessStepFunctions');
     if (plugin) {
-      const edgePort = this.getEdgePort();
-      const endpoint = `http://localhost:${edgePort}`
+      const endpoint = this.getServiceURL()
       plugin.originalDisplay = plugin.display;
       plugin.localstackEndpoint = endpoint;
 

--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,9 @@ class LocalstackPlugin {
       const replace = 'http://localhost:' + edgePort + '/restapis/$1/$2/_user_request_$3';
       endpoints[idx] = entry.replace(regex, replace);
     });
+    
+    // Replace ServerlessStepFunctions display
+    this.stepFunctionsReplaceDisplay()
   }
 
   /**
@@ -596,6 +599,26 @@ class LocalstackPlugin {
 
   clone(obj) {
     return JSON.parse(JSON.stringify(obj));
+  }
+  
+  stepFunctionsReplaceDisplay() {
+    const plugin = this.findPlugin('ServerlessStepFunctions');
+    if (plugin) {
+      const edgePort = this.getEdgePort();
+      const endpoint = `http://localhost:${edgePort}`
+      plugin.originalDisplay = plugin.display;
+      plugin.localstackEndpoint = endpoint;
+
+      const newDisplay = function () {
+        const regex = /.*:\/\/([^.]+)\.execute-api[^/]+\/([^/]+)(\/.*)?/g;
+        let newEndpoint = this.localstackEndpoint +'/restapis/$1/$2/_user_request_$3'
+        this.endpointInfo = this.endpointInfo.replace(regex, newEndpoint)
+        this.originalDisplay();
+      }
+      
+      newDisplay.bind(plugin)
+      plugin.display = newDisplay;
+    }
   }
 
 }


### PR DESCRIPTION
Now this plugin replaces the display function of the Serverless StepFunctions plugin so the urls show at the end target the localstack Service like this:

Adresses localstack/localstack#3777

```
.......................................
Serverless: Stack create finished...
Service Information
service: test-parallel
stage: local
region: us-east-1
stack: test-parallel-local
resources: 15
api keys:
  None
endpoints:
  http://localhost:4566/restapis/4ltgvogrhk/local/_user_request_
functions:
  hello: test-parallel-local-hello
layers:
  None
Serverless StepFunctions OutPuts
endpoints:
  GET - http://localhost:4566/restapis/4ltgvogrhk/local/_user_request_/step/function1
  GET - http://localhost:4566/restapis/4ltgvogrhk/local/_user_request_/step/function2

```