### PR TITLE
Added webpack support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ custom:
     webpackConfig: webpack.config.js
     includeModules: true
     keepoutputDirectory: true
-  localstack
+  localstack:
     stages:
       - local
     lambda:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ custom:
       - local
     lambda:
       mountCode: true
-    autostart: true
+    autoStart: true
 ```
 
 ### Environment Configurations

--- a/README.md
+++ b/README.md
@@ -68,7 +68,62 @@ into the Docker container that runs the Lambda code in LocalStack. If you remove
 flag, your Lambda code is deployed in the traditional way which is more in line with
 how things work in AWS, but also comes with a performance penalty: packaging the code,
 uploading it to the local S3 service, downloading it in the local Lambda API, extracting
-it, and finally copying/mounting it into a Docker container to run the Lambda.
+it, and finally copying/mounting it into a Docker container to run the Lambda. Mounting code
+from multiple projects is not supported with simple configuration, and you must use the
+`autoStart` feature, as your code will be mounted in docker at start up. If you do need to
+mount code from multiple serverless projects, manually launch
+localstack with volumes specified. For example:
+
+```sh
+localstack infra start --docker -d \
+  -v /path/to/project-a:/path/to/project-a \
+  -v /path/to/project-b:/path/to/project-b
+```
+
+If you use either `serverless-webpack` or `serverless-plugin-typescript`, `serverless-localstack`
+will detect it and modify the mount paths to point to your output directory. You will need to invoke
+the build command in order for the mounted code to be updated. (eg: `serverless webpack`). There is no
+`--watch` support for this out of the box, but could be accomplished using nodemon:
+
+```sh
+npm i --save-dev nodemon
+```
+
+`package.json`:
+
+```json
+  "scripts": {
+    "build": "serverless webpack --stage local",
+    "deploy": "serverless deploy --stage local",
+    "watch": "nodemon -w src -e '.*' -x 'npm run build'",
+    "start": "npm run deploy && npm run watch"
+  },
+```
+
+```sh
+npm run start
+```
+
+#### A note on using webpack
+
+`serverless-webpack` is supported, with code mounting. However, there are some assumptions
+and configuration requirements. First, your output directory must be `.webpack`. Second, you must retain
+your output directory contents. You can do this by modifying the `custom > webpack` portion of your
+serverless configuration file.
+
+```yml
+custom:
+  webpack:
+    webpackConfig: webpack.config.js
+    includeModules: true
+    keepoutputDirectory: true
+  localstack
+    stages:
+      - local
+    lambda:
+      mountCode: true
+    autostart: true
+```
 
 ### Environment Configurations
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,13 @@ const exec = promisify(require('child_process').exec);
 const DEFAULT_STAGE = 'dev';
 // Strings or other values considered to represent "true"
 const TRUE_VALUES = ['1', 'true', true];
-// Build directory of serverless-plugin-typescript plugin
-const TYPESCRIPT_PLUGIN_BUILD_DIR = '.build';
+// Plugin naming and build directory of serverless-plugin-typescript plugin
+const TS_PLUGIN_TSC = 'TypeScriptPlugin'
+const TYPESCRIPT_PLUGIN_BUILD_DIR_TSC = '.build';
+// Plugin naming and build directory of serverless-webpack plugin
+const TS_PLUGIN_WEBPACK = 'ServerlessWebpack'
+const TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK = '.webpack/service';
+
 // Default edge port to use with host
 const DEFAULT_EDGE_PORT = '4566';
 
@@ -115,6 +120,23 @@ class LocalstackPlugin {
     // Activate the synchronous parts of plugin config here in the constructor, but
     // run the async logic in enablePlugin(..) later via the hooks.
     this.activatePlugin(true);
+
+    // If we're using webpack, we need to make sure we retain the compiler output directory
+    if (this.detectTypescriptPluginType() === TS_PLUGIN_WEBPACK) {
+      const p = this.serverless.pluginManager.plugins.find((x) => x.constructor.name === TS_PLUGIN_WEBPACK)
+      if (
+        this.shouldMountCode() && (
+          !p ||
+          !p.serverless ||
+          !p.serverless.configurationInput ||
+          !p.serverless.configurationInput.custom ||
+          !p.serverless.configurationInput.custom.webpack ||
+          !p.serverless.configurationInput.custom.webpack.keepOutputDirectory
+        )
+      ) {
+        throw new Error('When mounting Lambda code, you must retain webpack output directory. Set custom.webpack.keepOutputDirectory to true.')
+      }
+    }
   }
 
   addHookInFirstPosition(eventName, hookFunction) {
@@ -171,6 +193,7 @@ class LocalstackPlugin {
               // into the VM (e.g., "c:/users/guest/...").
               res.Properties.Code.S3Key = process.env.LAMBDA_MOUNT_CWD;
             }
+            console.log('res.Properties.Code.S3Key', res.Properties.Code.S3Key)
           }
         });
       });
@@ -179,8 +202,10 @@ class LocalstackPlugin {
     this.skipIfMountLambda('AwsCompileFunctions', 'downloadPackageArtifacts');
     this.skipIfMountLambda('AwsDeploy', 'extendedValidate');
     this.skipIfMountLambda('AwsDeploy', 'uploadFunctionsAndLayers');
-    this.skipIfMountLambda('TypeScriptPlugin', 'cleanup', null, [
-      'after:package:createDeploymentArtifacts', 'after:deploy:function:packageFunction']);
+    if (this.detectTypescriptPluginType()) {
+      this.skipIfMountLambda(this.detectTypescriptPluginType(), 'cleanup', null, [
+        'after:package:createDeploymentArtifacts', 'after:deploy:function:packageFunction']);
+    }
 
     this.pluginActivated = true;
   }
@@ -206,6 +231,21 @@ class LocalstackPlugin {
           this.patchS3BucketLocationResponse();
       }
     );
+  }
+
+  // Convenience method for detecting JS/TS transpiler
+  detectTypescriptPluginType() {
+    if (this.findPlugin(TS_PLUGIN_TSC)) return TS_PLUGIN_TSC
+    if (this.findPlugin(TS_PLUGIN_WEBPACK)) return TS_PLUGIN_WEBPACK
+    return undefined
+  }
+
+  // Convenience method for getting build directory of installed JS/TS transpiler
+  getTSBuildDir() {
+    const TS_PLUGIN = this.detectTypescriptPluginType()
+    if (TS_PLUGIN === TS_PLUGIN_TSC) return TYPESCRIPT_PLUGIN_BUILD_DIR_TSC
+    if (TS_PLUGIN === TS_PLUGIN_WEBPACK) return TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK
+    return undefined
   }
 
   findPlugin(name) {
@@ -385,13 +425,14 @@ class LocalstackPlugin {
         env.DEBUG = '1';
         env.LAMBDA_EXECUTOR = env.LAMBDA_EXECUTOR || 'docker';
         env.LAMBDA_REMOTE_DOCKER = env.LAMBDA_REMOTE_DOCKER || '0';
-        env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`;
+        env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`; // THIS IS THE MAGIC
         env.START_WEB = env.START_WEB || '0';
         const maxBuffer = (+env.EXEC_MAXBUFFER)||50*1000*1000; // 50mb buffer to handle output
         if (this.shouldRunDockerSudo()) {
           env.DOCKER_CMD = 'sudo docker';
         }
         const options = {env: env, maxBuffer};
+        console.log('Running', 'localstack infra start --docker', options)
         return exec('localstack infra start --docker', options).then(getContainer)
           .then((containerID) => checkStatus(containerID)
         );
@@ -404,7 +445,7 @@ class LocalstackPlugin {
    * used, and (2) lambda.mountCode is enabled.
    */
   patchTypeScriptPluginMountedCodeLocation() {
-    if (!this.shouldMountCode() || !this.findPlugin('TypeScriptPlugin')) {
+    if (!this.shouldMountCode() || !this.detectTypescriptPluginType()) {
       return;
     }
     const template = this.serverless.service.provider.compiledCloudFormationTemplate || {};
@@ -413,7 +454,7 @@ class LocalstackPlugin {
       (resName) => {
         const resEntry = resources[resName];
         if (resEntry.Type === 'AWS::Lambda::Function') {
-          resEntry.Properties.Handler = `${TYPESCRIPT_PLUGIN_BUILD_DIR}/${resEntry.Properties.Handler}`;
+          resEntry.Properties.Handler = `${this.getTSBuildDir()}/${resEntry.Properties.Handler}`;
         }
       }
     );

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,10 @@ const DEFAULT_STAGE = 'dev';
 const TRUE_VALUES = ['1', 'true', true];
 // Plugin naming and build directory of serverless-plugin-typescript plugin
 const TS_PLUGIN_TSC = 'TypeScriptPlugin'
-const TYPESCRIPT_PLUGIN_BUILD_DIR_TSC = '.build';
+const TYPESCRIPT_PLUGIN_BUILD_DIR_TSC = '.build'; //TODO detect from tsconfig.json
 // Plugin naming and build directory of serverless-webpack plugin
 const TS_PLUGIN_WEBPACK = 'ServerlessWebpack'
-const TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK = '.webpack/service';
+const TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK = '.webpack/service'; //TODO detect from webpack.config.js
 
 // Default edge port to use with host
 const DEFAULT_EDGE_PORT = '4566';
@@ -123,7 +123,7 @@ class LocalstackPlugin {
 
     // If we're using webpack, we need to make sure we retain the compiler output directory
     if (this.detectTypescriptPluginType() === TS_PLUGIN_WEBPACK) {
-      const p = this.serverless.pluginManager.plugins.find((x) => x.constructor.name === TS_PLUGIN_WEBPACK)
+      const p = this.serverless.pluginManager.plugins.find((x) => x.constructor.name === TS_PLUGIN_WEBPACK);
       if (
         this.shouldMountCode() && (
           !p ||
@@ -134,7 +134,8 @@ class LocalstackPlugin {
           !p.serverless.configurationInput.custom.webpack.keepOutputDirectory
         )
       ) {
-        throw new Error('When mounting Lambda code, you must retain webpack output directory. Set custom.webpack.keepOutputDirectory to true.')
+        throw new Error('When mounting Lambda code, you must retain webpack output directory. '
+          + 'Set custom.webpack.keepOutputDirectory to true.');
       }
     }
   }
@@ -193,7 +194,6 @@ class LocalstackPlugin {
               // into the VM (e.g., "c:/users/guest/...").
               res.Properties.Code.S3Key = process.env.LAMBDA_MOUNT_CWD;
             }
-            console.log('res.Properties.Code.S3Key', res.Properties.Code.S3Key)
           }
         });
       });
@@ -425,14 +425,13 @@ class LocalstackPlugin {
         env.DEBUG = '1';
         env.LAMBDA_EXECUTOR = env.LAMBDA_EXECUTOR || 'docker';
         env.LAMBDA_REMOTE_DOCKER = env.LAMBDA_REMOTE_DOCKER || '0';
-        env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`; // THIS IS THE MAGIC
+        env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`;
         env.START_WEB = env.START_WEB || '0';
         const maxBuffer = (+env.EXEC_MAXBUFFER)||50*1000*1000; // 50mb buffer to handle output
         if (this.shouldRunDockerSudo()) {
           env.DOCKER_CMD = 'sudo docker';
         }
         const options = {env: env, maxBuffer};
-        console.log('Running', 'localstack infra start --docker', options)
         return exec('localstack infra start --docker', options).then(getContainer)
           .then((containerID) => checkStatus(containerID)
         );


### PR DESCRIPTION
This adds `serverless-webpack` support and makes it compatible with the current `aws-nodejs-template` code. Resolves https://github.com/localstack/serverless-localstack/issues/42