### PR TITLE
Solve issue with step function endpointInfo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -659,7 +659,9 @@ class LocalstackPlugin {
       const newDisplay = function () {
         const regex = /.*:\/\/([^.]+)\.execute-api[^/]+\/([^/]+)(\/.*)?/g;
         let newEndpoint = this.localstackEndpoint +'/restapis/$1/$2/_user_request_$3'
-        this.endpointInfo = this.endpointInfo.replace(regex, newEndpoint)
+        if(this.endpointInfo) {
+          this.endpointInfo = this.endpointInfo.replace(regex, newEndpoint)
+        }
         this.originalDisplay();
       }
       


### PR DESCRIPTION
# Description

Sometimes, the step function doesn't have an endpoint and the property `endpointInfo` isn't initialized, in those cases will throw an error because `this.endpointInfo` is undefined. This conditional solves that error.

[Source code](https://github.com/serverless-operations/serverless-step-functions/blob/7c6f8ece01729e70b8557d1b0a4d2a285b049af1/lib/deploy/events/apiGateway/endpointInfo.js#L21)
Regex used in the source code: `/^(ServiceEndpoint|HttpApiUrl)/`

## Hotfix
Until this PR is accepted, I solved the issue by adding an output:
```
resources:
    Outputs:
        ServiceEndpointIssueBypass: # This bypass is temporal due to an issue with the serverless-localstack plugin
            Value: ''
```
# Changes
## General

### Bug Fixes

- Solve an issue where the endpointInfo isn't defined (b2cbf9141643dce432fa7e7a4ba93fd85a8c45de)


