### PR TITLE
Feature/networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ custom:
 
 ## Change Log
 
-* v0.4.34: Add config option to connect to additional docker networks
+* v0.4.35: Add config option to connect to additional docker networks
 * v0.4.33: Fix parsing StepFunctions endpoint if the endpointInfo isn't defined
 * v0.4.32: Add endpoint to AWS credentials for compatibility with serverless-domain-manager plugin
 * v0.4.31: Fix format of API GW endpoints printed in stack output

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ custom:
     host: http://localhost  # optional - LocalStack host to connect to
     edgePort: 4566  # optional - LocalStack edge port to connect to
     autostart: true  # optional - Start LocalStack in Docker on Serverless deploy
+    networks: #optional - attaches the list of networks to the localstack docker container after startup
+      - host
+      - overlay
+      - my_custom_network
     lambda:
       # Enable this flag to improve performance
       mountCode: True

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ custom:
 
 ## Change Log
 
+* v0.4.34: Add config option to connect to additional docker networks
 * v0.4.33: Fix parsing StepFunctions endpoint if the endpointInfo isn't defined
 * v0.4.32: Add endpoint to AWS credentials for compatibility with serverless-domain-manager plugin
 * v0.4.31: Fix format of API GW endpoints printed in stack output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -421,7 +421,6 @@ class LocalstackPlugin {
     }
 
     const addNetworks = async (containerID) => {
-      let networks = [];
       if(this.config.networks) {
         for(var network in this.config.networks) {
           await exec(`docker network connect "${this.config.networks[network]}" ${containerID}`);

--- a/src/index.js
+++ b/src/index.js
@@ -420,6 +420,16 @@ class LocalstackPlugin {
       });
     }
 
+    const addNetworks = async (containerID) => {
+      let networks = [];
+      if(this.config.networks) {
+        for(var network in this.config.networks) {
+          await exec(`docker network connect ${this.config.networks[network]} ${containerID}`);
+        }
+      }
+      return containerID;
+    }
+    
     return getContainer().then(
       (containerID) => {
         if(containerID) {
@@ -439,8 +449,8 @@ class LocalstackPlugin {
         }
         const options = {env: env, maxBuffer};
         return exec('localstack start', options).then(getContainer)
-          .then((containerID) => checkStatus(containerID)
-        );
+          .then((containerID) => addNetworks(containerID))
+          .then((containerID) => checkStatus(containerID));
       }
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -424,7 +424,7 @@ class LocalstackPlugin {
       let networks = [];
       if(this.config.networks) {
         for(var network in this.config.networks) {
-          await exec(`docker network connect ${this.config.networks[network]} ${containerID}`);
+          await exec(`docker network connect "${this.config.networks[network]}" ${containerID}`);
         }
       }
       return containerID;


### PR DESCRIPTION
Allows the localstack container to connect to additional networks on container creation

usage:
```yaml
...
custom:
  localstack:
    networks:
      - "bridge"
      - "overlay"
      - "host"
      - "my_custom_network"
...
```

The network must already exist before container creation