### PR TITLE
Resolving issue related to webpack mounted code location

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -459,7 +459,7 @@ class LocalstackPlugin {
    * used, and (2) lambda.mountCode is enabled.
    */
   patchTypeScriptPluginMountedCodeLocation() {
-    if (!this.shouldMountCode() || !this.detectTypescriptPluginType()) {
+    if (!this.shouldMountCode() || !this.detectTypescriptPluginType() || !this.isActive()) {
       return;
     }
     const template = this.serverless.service.provider.compiledCloudFormationTemplate || {};


### PR DESCRIPTION
The plugin works well when bundling with webpack and deploying to localstack, however it also interferes with the paths in the cloudformation template generated when deploying with serverless to aws. In this scenario the lambda handlers receive an incorrect path (`.webpack/service/src/...` instead of `src/...`). This PR disables the modification of mounted path when deploying to a staged environment in AWS.
#171: disabling update of mounted code location when serverless-localstack is not active