### PR TITLE
Feature/194 support for serverless esbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 example/service/.serverless
 example/service/.serverless_plugins
+.idea

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ localstack start --docker -d \
   -v /path/to/project-b:/path/to/project-b
 ```
 
-If you use either `serverless-webpack` or `serverless-plugin-typescript`, `serverless-localstack`
+If you use either `serverless-webpack`, `serverless-plugin-typescript`, or `serverless-esbuild`, `serverless-localstack`
 will detect it and modify the mount paths to point to your output directory. You will need to invoke
 the build command in order for the mounted code to be updated. (eg: `serverless webpack`). There is no
 `--watch` support for this out of the box, but could be accomplished using nodemon:
@@ -96,7 +96,7 @@ the build command in order for the mounted code to be updated. (eg: `serverless 
 npm i --save-dev nodemon
 ```
 
-`package.json`:
+Webpack example's `package.json`:
 
 ```json
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ const TYPESCRIPT_PLUGIN_BUILD_DIR_TSC = '.build'; //TODO detect from tsconfig.js
 // Plugin naming and build directory of serverless-webpack plugin
 const TS_PLUGIN_WEBPACK = 'ServerlessWebpack'
 const TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK = '.webpack/service'; //TODO detect from webpack.config.js
+// Plugin naming and build directory of serverless-webpack plugin
+const TS_PLUGIN_ESBUILD = 'EsbuildServerlessPlugin'
+const TYPESCRIPT_PLUGIN_BUILD_DIR_ESBUILD = '.esbuild/.build'; //TODO detect from esbuild.config.js
 
 // Default edge port to use with host
 const DEFAULT_EDGE_PORT = '4566';
@@ -248,6 +251,7 @@ class LocalstackPlugin {
   detectTypescriptPluginType() {
     if (this.findPlugin(TS_PLUGIN_TSC)) return TS_PLUGIN_TSC
     if (this.findPlugin(TS_PLUGIN_WEBPACK)) return TS_PLUGIN_WEBPACK
+    if (this.findPlugin(TS_PLUGIN_ESBUILD)) return TS_PLUGIN_ESBUILD
     return undefined
   }
 
@@ -256,6 +260,7 @@ class LocalstackPlugin {
     const TS_PLUGIN = this.detectTypescriptPluginType()
     if (TS_PLUGIN === TS_PLUGIN_TSC) return TYPESCRIPT_PLUGIN_BUILD_DIR_TSC
     if (TS_PLUGIN === TS_PLUGIN_WEBPACK) return TYPESCRIPT_PLUGIN_BUILD_DIR_WEBPACK
+    if (TS_PLUGIN === TS_PLUGIN_ESBUILD) return TYPESCRIPT_PLUGIN_BUILD_DIR_ESBUILD
     return undefined
   }
 


### PR DESCRIPTION
Added support for serverless-esbuild.

Fixes: #194 

## TODO

In theory, code mounting should also work with esbuild and typescript, but has not been tested. 

1. Test esbuild integration
2. Test code mounting with esbuild
3. Test code mounting with typescript

Note that in all cases, the output directory probably must be the default that esbuild, typescript or webpack use.
