### PR TITLE
fix internal Serverless custom resources S3 path addressing

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ custom:
 
 ## Change Log
 
+* v1.0.3: Set S3 Path addressing for internal Serverless Custom Resources - allow configuring S3 Events Notification for functions
 * v1.0.2: Add check to prevent IPv6 connection issue with `localhost` on MacOS
 * v1.0.1: Add support for Serverless projects with esbuild source config; enable config via environment variables
 * v1.0.0: Allow specifying path for mountCode, to point to a relative Lambda mount path

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "aws-sdk": "^2.402.0",
         "es6-promisify": "^6.0.1"
       },
@@ -1051,7 +1052,6 @@
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
       "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -9765,8 +9765,7 @@
     "adm-zip": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
-      "dev": true
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "after": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {
@@ -25,7 +25,8 @@
     "Waldemar Hummer (whummer)",
     "Justin McCormick <me@justinmccormick.com>",
     "djKooks",
-    "yohei1126"
+    "yohei1126",
+    "bentsku"
   ],
   "license": "MIT",
   "bugs": {
@@ -33,6 +34,7 @@
   },
   "homepage": "https://github.com/localstack/serverless-localstack",
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "aws-sdk": "^2.402.0",
     "es6-promisify": "^6.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,10 @@ class LocalstackPlugin {
     // Add a hook to fix TypeError when accessing undefined state attribute
     this.addHookInFirstPosition('before:aws:deploy:deploy:checkForChanges', this.beforeDeployCheckForChanges);
 
+    this.serverless.pluginManager.hooks['package:compileEvents'].push({
+      pluginName: 'LocalstackPlugin', hook: this.patchCustomResourceLambdaS3ForcePathStyle.bind(this)
+    });
+
     this.awsServices = [
       'acm',
       'amplify',

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,8 @@ class LocalstackPlugin {
     // Add a hook to fix TypeError when accessing undefined state attribute
     this.addHookInFirstPosition('before:aws:deploy:deploy:checkForChanges', this.beforeDeployCheckForChanges);
 
-    this.serverless.pluginManager.hooks['package:compileEvents'].push({
+    const compileEventsHooks = this.serverless.pluginManager.hooks['package:compileEvents'] || [];
+    compileEventsHooks.push({
       pluginName: 'LocalstackPlugin', hook: this.patchCustomResourceLambdaS3ForcePathStyle.bind(this)
     });
 


### PR DESCRIPTION
While debugging a support case about `serverless-python-requirements`, I stumbled upon an issue regarding Serverless own internal Custom Resources: they would spin up a lambda to update the notification configuration of an existing S3 bucket. However, they would try to access it using virtual host addressing, leading to the lambda failing and the bucket not getting the right configuration. You can reproduce it using this kind of function events:

```yaml
functions:
  s3_to_dynamodb:
    handler: lambda_functions/s3_to_dynamodb.lambda_handler
    events:
      - s3:
          bucket: test-bucket
          event: s3:ObjectCreated:*
          rules:
            - suffix: .csv
          existing: true
```

The deployment would not fail, but the S3 bucket would not trigger the lambda.

This PR introduces a mechanism to hook into `package:compileEvents` which is triggered when building resources to manage `events`. We're checking for the presence of the `custom-resources.zip` file, which would be created if Serverless was going to package its internal custom-resources to create its lambdas. 
We then get the `utils.js` file which is imported by all lambdas, and set the SDK config there to use `S3forcePathStyle=true`. 
As there are nothing in the node standard library to unzip file, I had to introduce a new dependency, `adm-zip`.

Relevant documentation:
- Lifecycle Events - Serverless : https://www.serverless.com/framework/docs/guides/plugins/creating-plugins#lifecycle-events
- Every lifecycle listed: https://gist.github.com/HyperBrain/50d38027a8f57778d5b0f135d80ea406
- adm-zip: https://github.com/cthackers/adm-zip
- adm-zip on DigitalOcean: https://www.digitalocean.com/community/tutorials/how-to-work-with-zip-files-in-node-js