### PR TITLE
Fix nodejs 17 localhost connection error with ipv4 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ custom:
 
 ## Change Log
 
+* v1.0.4: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * v1.0.3: Set S3 Path addressing for internal Serverless Custom Resources - allow configuring S3 Events Notification for functions
 * v1.0.2: Add check to prevent IPv6 connection issue with `localhost` on MacOS
 * v1.0.1: Add support for Serverless projects with esbuild source config; enable config via environment variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -670,21 +670,52 @@ class LocalstackPlugin {
       }
     }
 
-    // attempt to connect to the given host/port
-    const socket = new net.Socket();
-    try {
-      await socket.connect({ host: hostname, port });
-    } catch (e) {
-      if (hostname === 'localhost') {
-        // fall back to using local IPv4 address - to fix IPv6 issue on MacOS
-        // see, https://github.com/localstack/serverless-localstack/issues/125
-        return "127.0.0.1";
+    // Fall back to using local IPv4 address if connection to localhost fails.
+    // This workaround transparently handles systems (e.g., macOS) where
+    // localhost resolves to IPv6 when using Nodejs >=v17. See discussion:
+    // https://github.com/localstack/aws-cdk-local/issues/76#issuecomment-1412590519
+    // Issue: https://github.com/localstack/serverless-localstack/issues/125
+    if (hostname === "localhost") {
+      try {
+        const options = { host: hostname, port: port };
+        await this.checkTCPConnection(options);
+      } catch (e) {
+        const fallbackHostname = "127.0.0.1"
+        this.debug(`Reconfiguring hostname to use ${fallbackHostname} (IPv4) because connection to ${hostname} failed`);
+        hostname = fallbackHostname;
       }
-    } finally {
-      socket.destroy();
     }
 
     return hostname;
+  }
+
+  /**
+   * Checks whether a TCP connection to the given "options" can be established.
+   * @param {object} options connection options of net.socket.connect()
+   *                 https://nodejs.org/api/net.html#socketconnectoptions-connectlistener
+   *                 Example: { host: "localhost", port: 4566 }
+   * @returns {Promise} A fulfilled empty promise on successful connection and
+   *                    a rejected promise on any connection error.
+   */
+  async checkTCPConnection(options) {
+    return new Promise((resolve, reject) => {
+      const socket = new net.Socket();
+      const client = socket.connect(options, () => {
+        client.end();
+        resolve();
+      });
+
+      client.setTimeout(500);  // milliseconds
+      client.on("timeout", err => {
+        client.destroy();
+        reject(err);
+      });
+
+      client.on("error", err => {
+        client.destroy();
+        reject(err);
+      });
+    });
   }
 
   getAwsProvider() {

--- a/src/index.js
+++ b/src/index.js
@@ -697,7 +697,7 @@ class LocalstackPlugin {
    * @returns {Promise} A fulfilled empty promise on successful connection and
    *                    a rejected promise on any connection error.
    */
-  async checkTCPConnection(options) {
+  checkTCPConnection(options) {
     return new Promise((resolve, reject) => {
       const socket = new net.Socket();
       const client = socket.connect(options, () => {


### PR DESCRIPTION
This PR transparently circumvents connection issues with Nodejs >=v17 on macOS because localhost resolves to IPv6. It fixes a Javascript error in the `getConnectHostname()` workaround from the previous PR https://github.com/localstack/aws-cdk-local/pull/79

Full explanation in https://github.com/localstack/aws-cdk-local/issues/76#issuecomment-1412590519

Addresses:

* https://github.com/localstack/serverless-localstack/issues/125

cdklocal companion PR: https://github.com/localstack/aws-cdk-local/pull/80

## Problem

net.Socket.connect used [here](https://github.com/localstack/serverless-localstack/pull/205/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R670) does not support promises. Hence, the try-catch block has no effect.

## Solution

* Add a helper `checkTCPConnection()` that adds support for promises by mapping socket events such as `on("error")`.
* Only run the fallback check if hostname is `localhost`

## Testing

Tested on macOS 13.1 with Node v19.

Standalone Node example to reproduce IPv6 issue:

```js
const socket = new net.Socket();

var hostname = 'localhost'
hostname = '127.0.0.1'
const port = 4566

socket.connect({ host: hostname, port }, () => {
  console.log(`connected to ${hostname}:${port}`)
})
```
