### PR TITLE
[Bug fix] Resolving issue with "://" index check always processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -672,7 +672,7 @@ class LocalstackPlugin {
     var hostname = process.env.LOCALSTACK_HOSTNAME || 'localhost';
     if (this.config.host) {
       hostname = this.config.host;
-      if (hostname.indexOf("://")) {
+      if (hostname.indexOf("://") !== -1) {
         hostname = new URL(hostname).hostname;
       }
     }


### PR DESCRIPTION
Resolving a bug where the checks to see if `this.config.host` contains :// always returns true resulting in exceptions for invalid uri.

This is happening because indexOf returns -1 not false resulting in the value always technically being true.