### PR TITLE
add BUCKET_MARKER_LOCAL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ custom:
    see [LocalStack repo](https://github.com/localstack/localstack)
 * `LAMBDA_REMOTE_DOCKER`: Whether to assume that we're running Lambda containers against
    a remote Docker daemon (default `false`) - see [LocalStack repo](https://github.com/localstack/localstack)
+* `BUCKET_MARKER_LOCAL`: Magic S3 bucket name for Lambda mount and [Hot Reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading/).
 
 ### Only enable serverless-localstack for the listed stages
 * ```serverless deploy --stage local``` would deploy to LocalStack.
@@ -205,6 +206,7 @@ custom:
 
 ## Change Log
 
+* v1.0.6: Add `BUCKET_MARKER_LOCAL` configuration for customizing S3 bucket for lambda mount and [Hot Reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading/).
 * v1.0.5: Fix S3 Bucket LocationConstraint issue when the provider region is `us-east-1`
 * v1.0.4: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS
 * v1.0.3: Set S3 Path addressing for internal Serverless Custom Resources - allow configuring S3 Events Notification for functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,8 @@ class LocalstackPlugin {
         Object.keys(resources).forEach(id => {
           const res = resources[id];
           if (res.Type === 'AWS::Lambda::Function') {
-            res.Properties.Code.S3Bucket = '__local__';
+            // TODO: change the default BUCKET_MARKER_LOCAL to 'hot-reload'
+            res.Properties.Code.S3Bucket = process.env.BUCKET_MARKER_LOCAL || '__local__'; // for now, the default is still __local__
             res.Properties.Code.S3Key = process.cwd();
             const mountCode = this.config.lambda.mountCode;
             if (typeof mountCode === 'string' && mountCode.toLowerCase() !== 'true') {


### PR DESCRIPTION
Adding the `BUCKET_MARKER_LOCAL`, same as LocalStack configuration, please feel free to correct the name, I don't have much inspiration! For now, the default is still `__local__` but we can now set it to `hot-reload` with this environment variable. 