### PR TITLE
run interceptRequest async

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ custom:
 
 ## Change Log
 
+* v1.1.0: Fix SSM environment variables resolving issues with serverless v3, change default for `BUCKET_MARKER_LOCAL` to `hot-reload`
 * v1.0.6: Add `BUCKET_MARKER_LOCAL` configuration for customizing S3 bucket for lambda mount and [Hot Reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading/).
 * v1.0.5: Fix S3 Bucket LocationConstraint issue when the provider region is `us-east-1`
 * v1.0.4: Fix IPv4 fallback check to prevent IPv6 connection issue with `localhost` on macOS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/spec/helpers/services.js
+++ b/spec/helpers/services.js
@@ -14,7 +14,10 @@ const defaultConfig = {
   provider: {
     name: 'aws',
     runtime: 'nodejs12.x',
-    lambdaHashingVersion: '20201221'
+    lambdaHashingVersion: '20201221',
+    environment: {
+        LAMBDA_STAGE: '${ssm:/${opt:stage, self:provider.stage}/lambda/common/LAMBDA_STAGE}'
+      }
   },
   plugins: [
     'serverless-localstack'

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -27,10 +27,9 @@ describe('LocalstackPlugin', () => {
     // return promise here because ssm.putParameter is async
     return new Promise((resolve, reject) => {
       // create SSM parameter that will be used for the setup
-      ssm.putParameter(params, function(err, data) { 
+      ssm.putParameter(params, function(err, data) { // eslint-disable-line
         if (err) {
           reject(err);
-          console.log(err, err.stack);
         } else {
           // if successful: create the actual service
           self.service = services.createService({});

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -3,11 +3,41 @@
 const services = require('../helpers/services');
 
 const LONG_TIMEOUT = 30000;
+const AWS = require('aws-sdk');
+
+// Set the region and endpoint in the config for LocalStack
+AWS.config.update({
+  region: 'us-east-1',
+  endpoint: 'http://localhost:4566'
+});
+const ssm = new AWS.SSM();
+
+const params = {
+  Name: '/dev/lambda/common/LAMBDA_STAGE',
+  Type: 'String',
+  Value: 'my-value',
+  Overwrite: true
+};
 
 describe('LocalstackPlugin', () => {
 
   beforeEach( () => {
-    this.service = services.createService({});
+    
+    const self = this;
+    // return promise here because ssm.putParameter is async
+    return new Promise((resolve, reject) => {
+      // create SSM parameter that will be used for the setup
+      ssm.putParameter(params, function(err, data) { 
+        if (err) {
+          reject(err);
+          console.log(err, err.stack);
+        } else {
+          // if successful: create the actual service
+          self.service = services.createService({});
+          resolve(self.service);
+        }
+      });
+    });
   });
 
   afterEach( () => {

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -10,6 +10,11 @@ AWS.config.update({
   region: 'us-east-1',
   endpoint: 'http://localhost:4566'
 });
+AWS.config.credentials = new AWS.Credentials({
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+});
+
 const ssm = new AWS.SSM();
 
 const params = {

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -26,22 +26,10 @@ const params = {
 
 describe('LocalstackPlugin', () => {
 
-  beforeEach( () => {
-    
-    const self = this;
-    // return promise here because ssm.putParameter is async
-    return new Promise((resolve, reject) => {
-      // create SSM parameter that will be used for the setup
-      ssm.putParameter(params, function(err, data) { // eslint-disable-line
-        if (err) {
-          reject(err);
-        } else {
-          // if successful: create the actual service
-          self.service = services.createService({});
-          resolve(self.service);
-        }
-      });
-    });
+  beforeEach( 
+    async () => {
+      await ssm.putParameter(params).promise();
+      this.service = services.createService({});
   });
 
   afterEach( () => {

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -184,7 +184,7 @@ describe("LocalstackPlugin", () => {
       instance = new LocalstackPlugin(serverless, defaultPluginState)
       await simulateBeforeDeployHooks(instance);
 
-      awsProvider.request('S3', 'validateTemplate', {});
+      await awsProvider.request('S3', 'validateTemplate', {});
 
       expect(request.called).to.be.false;
     });

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -171,7 +171,7 @@ describe("LocalstackPlugin", () => {
       instance = new LocalstackPlugin(serverless, defaultPluginState);
       await simulateBeforeDeployHooks(instance);
 
-      awsProvider.request('s3', 'foo', {
+      await awsProvider.request('s3', 'foo', {
         TemplateURL: pathToTemplate
       });
       expect(request.called).to.be.true;

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,6 @@ class LocalstackPlugin {
   }
 
   async init() {
-    this.activatePlugin()
     await this.reconfigureAWS()
   }
 
@@ -174,16 +173,6 @@ class LocalstackPlugin {
       const awsProvider = this.getAwsProvider();
       this.awsProviderRequest = awsProvider.request.bind(awsProvider);
       awsProvider.request = this.interceptRequest.bind(this);
-    }
-
-    // Reconfigure AWS clients
-    try {
-      this.reconfigureAWS();
-    } catch (e) {
-      // This can happen if we are executing in the plugin initialization context and
-      // the template variables have not been fully initialized yet
-      // (e.g., "Error: Profile ${self:custom.stage}Profile does not exist")
-      return;
     }
 
     // Patch plugin methods

--- a/src/index.js
+++ b/src/index.js
@@ -566,7 +566,7 @@ class LocalstackPlugin {
    */
   async reconfigureAWS() {
     if(this.isActive()) {
-      if(this.reconfigured_endpoints){
+      if(this.reconfiguredEndpoints){
         this.debug("Skipping reconfiguring of endpoints (already reconfigured)")
         return;
       }
@@ -624,7 +624,7 @@ class LocalstackPlugin {
         awsProvider.cachedCredentials.endpoint = localEndpoint;
       }
       this.log("serverless-localstack: Reconfigured endpoints")
-      this.reconfigured_endpoints = true;
+      this.reconfiguredEndpoints = true;
     }
     else {
       this.endpoints = {}

--- a/src/index.js
+++ b/src/index.js
@@ -189,8 +189,7 @@ class LocalstackPlugin {
         Object.keys(resources).forEach(id => {
           const res = resources[id];
           if (res.Type === 'AWS::Lambda::Function') {
-            // TODO: change the default BUCKET_MARKER_LOCAL to 'hot-reload'
-            res.Properties.Code.S3Bucket = process.env.BUCKET_MARKER_LOCAL || '__local__'; // for now, the default is still __local__
+            res.Properties.Code.S3Bucket = process.env.BUCKET_MARKER_LOCAL || 'hot-reload'; // default changed to 'hot-reload' with LS v2 release
             res.Properties.Code.S3Key = process.cwd();
             const mountCode = this.config.lambda.mountCode;
             if (typeof mountCode === 'string' && mountCode.toLowerCase() !== 'true') {


### PR DESCRIPTION
Issue: resolving the environment variable still sends the request to AWS, because reconfiguring the endpoint is running async, and is not finished when the `getParameter SSM` is called, resulting in error:
```
aws: [1] { UnrecognizedClientException: The security token included in the request is invalid.
    at Request.extractError (/path/ls-lambda/node_modules/aws-sdk/lib/protocol/json.js:52:27)
    at Request.callListeners (/path/ls-lambda/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/path/ls-lambda/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
   ....

'Cannot resolve serverless.yml: Variables resolution errored with:\n  - Cannot resolve variable at "provider.environment.LAMBDA_STAGE": The security token included in the request is invalid.',
```
This is triggered by the following configuration for `LAMBDA_STAGE`:
```
provider:
  name: aws
  runtime: nodejs18.x
  stage: dev
  region: eu-west-1
  memorySize: 512
  timeout: 60
  iam:
    role:
      statements:
        - Effect: 'Allow'
          Resource: '*'
          Action:
            - 'lambda:InvokeFunction'
            ....
  environment:
    LAMBDA_STAGE: ${ssm:/${opt:stage, self:provider.stage}/lambda/common/LAMBDA_STAGE}
```

* It turns out, that in this case (for resolving the `environment` variable) the intercept-hook `interceptRequest` is triggered
   * the function `interceptRequest` is a patching [aws.request](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L1683-L1697), which is already`async`. 
   * changing function to `async interceptRequest`,  and adding `await` for the aws-reconfiguration. 
   * added `init` hook that will also await the aws-reconfiguration
 
* changed the default for `BUCKET_MARKER_LOCAL` to hot-reload
 
