### PR TITLE
CI update: node 18 + run tests for serverless v2 and v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18'
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules-v${{ matrix.sls-major-version }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Cache node modules
         uses: actions/cache@v2
         env:
-          cache-name: cache-node-modules-v$${{ matrix.sls-major-version }}
+          cache-name: cache-node-modules-v${{ matrix.sls-major-version }}
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-$${{ matrix.sls-major-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.sls-major-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.sls-major-version }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           EXPECTED_SLS_MAJOR_VERSION: ${{ matrix.sls-major-version }}
         run : |
-          installed_sls_version=$(npm list | grep serverless | grep '@2\.')
+          installed_sls_version=$(npm list | grep serverless@ | sed -E 's/.*serverless@(.*)/\1/')
           echo "installed serverless version: ${installed_sls_version}"
           if [ "${installed_sls_version:0:1}" !=  ${EXPECTED_SLS_MAJOR_VERSION} ]; then
             echo "expected version ${EXPECTED_SLS_MAJOR_VERSION}, but installed ${installed_sls_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,12 @@ jobs:
       - name: Cache node modules
         uses: actions/cache@v2
         env:
-          cache-name: cache-node-modules
+          cache-name: cache-node-modules-v$${{ matrix.sls-major-version }}
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-$${{ matrix.sls-major-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.sls-major-version }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: Start LocalStack
         run: |
@@ -45,7 +43,7 @@ jobs:
         run: |
           npm ci
 
-      - name: Update SLS versions
+      - name: Update SLS version to v3
         if: ${{ matrix.sls-major-version == '3' }}
         run: |
           npm install serverless@3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.sls-major-version }}-
 
-      - name: Start LocalStack
-        run: |
-          pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack
-          localstack start -d
-          localstack wait -t 30
-
       - name: Install deps
         run: |
-          npm ci
+          # uninstall any existing global serverless installations, if exists
+          npm uninstall -g serverless || true
+          npm uninstall serverless || true
+          npm info serverless version
+          # install dependencies
+          npm install
 
       - name: Update SLS version to v3
         if: ${{ matrix.sls-major-version == '3' }}
@@ -58,6 +56,13 @@ jobs:
             echo "expected version ${EXPECTED_SLS_MAJOR_VERSION}, but installed ${installed_sls_version}"
             exit 1
           fi
+
+      - name: Start LocalStack
+        run: |
+          pip install localstack awscli-local[ver1]
+          docker pull localstack/localstack
+          localstack start -d
+          localstack wait -t 30
 
       - name: Run Lint and Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,54 @@ jobs:
         run: |
           npm link
           sleep 5; SLS_DEBUG=1 npm run test:integration
+
+  serverless-v3-localstack-test: 
+    name: Serverless v3 LocalStack CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Modify package.json
+        run: |
+          sed -i 's/"serverless": "\^2\.30\.0"/"serverless": "^3\.30\.0"/g' package.json
+          cat package.json
+      
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules-v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}-v3
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Start LocalStack
+        run: |
+          pip install localstack awscli-local[ver1]
+          docker pull localstack/localstack
+          localstack start -d
+          localstack wait -t 30
+
+      - name: Install deps
+        run: |
+          npm ci
+
+      - name: Run Lint and Test
+        run: |
+          set -e
+          npm run lint
+          npm run test
+
+      - name: Integration Tests
+        run: |
+          npm link
+          sleep 5; SLS_DEBUG=1 npm run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,6 @@ jobs:
 
       - name: Install deps
         run: |
-          # uninstall any existing global serverless installations, if exists
-          npm uninstall -g serverless || true
-          npm uninstall serverless || true
-          npm info serverless version
-          # install dependencies
           npm install
 
       - name: Update SLS version to v3
@@ -50,7 +45,7 @@ jobs:
         env:
           EXPECTED_SLS_MAJOR_VERSION: ${{ matrix.sls-major-version }}
         run : |
-          installed_sls_version=$(npm info serverless version)
+          installed_sls_version=$(npm list | grep serverless | grep '@2\.')
           echo "installed serverless version: ${installed_sls_version}"
           if [ "${installed_sls_version:0:1}" !=  ${EXPECTED_SLS_MAJOR_VERSION} ]; then
             echo "expected version ${EXPECTED_SLS_MAJOR_VERSION}, but installed ${installed_sls_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           npm ci
 
       - name: Update SLS versions
-        if: ${{ matrix.sls-major-version }} == '3'
+        if: ${{ matrix.sls-major-version == '3' }}
         run: |
           npm install serverless@3
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
           sed -i 's/"serverless": "\^2\.30\.0"/"serverless": "^3\.30\.0"/g' package.json
           cat package.json
       
+      - name: Update package-lock.json
+        run: |
+          npm install
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '18'
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   serverless-localstack-test:
     name: Serverless LocalStack CI
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sls-major-version: ["2", "3"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -25,9 +28,9 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-$${{ matrix.sls-major-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.sls-major-version }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
@@ -42,60 +45,21 @@ jobs:
         run: |
           npm ci
 
-      - name: Run Lint and Test
+      - name: Update SLS versions
+        if: ${{ matrix.sls-major-version }} == '3'
         run: |
-          set -e
-          npm run lint
-          npm run test
-
-      - name: Integration Tests
-        run: |
-          npm link
-          sleep 5; SLS_DEBUG=1 npm run test:integration
-
-  serverless-v3-localstack-test: 
-    name: Serverless v3 LocalStack CI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@v2
-        with:
-          node-version: '18'
-
-      - name: Modify package.json
-        run: |
-          sed -i 's/"serverless": "\^2\.30\.0"/"serverless": "^3\.30\.0"/g' package.json
-          cat package.json
+          npm install serverless@3
       
-      - name: Update package-lock.json
-        run: |
-          npm install
-
-      - name: Cache node modules
-        uses: actions/cache@v2
+      - name: Check installed version
         env:
-          cache-name: cache-node-modules-v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}-v3
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Start LocalStack
-        run: |
-          pip install localstack awscli-local[ver1]
-          docker pull localstack/localstack
-          localstack start -d
-          localstack wait -t 30
-
-      - name: Install deps
-        run: |
-          npm ci
+          EXPECTED_SLS_MAJOR_VERSION: ${{ matrix.sls-major-version }}
+        run : |
+          installed_sls_version=$(npm info serverless version)
+          echo "installed serverless version: ${installed_sls_version}"
+          if [ "${installed_sls_version:0:1}" !=  ${EXPECTED_SLS_MAJOR_VERSION} ]; then
+            echo "expected version ${EXPECTED_SLS_MAJOR_VERSION}, but installed ${installed_sls_version}"
+            exit 1
+          fi
 
       - name: Run Lint and Test
         run: |

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "test:watch": "JASMINE_CONFIG_PATH=spec/support/jasmine.json jasmine",
     "test:integration": "JASMINE_CONFIG_PATH=spec/support/jasmine_integration.json jasmine",
     "test:integration:watch": "JASMINE_CONFIG_PATH=spec/support/jasmine_integration.json nodemon -L -i spec/integrate ./node_modules/.bin/jasmine",
-    "test:cover": "jasmine --coverage",
-    "prepublish": "npm run test",
-    "preversion": "npm run test"
+    "test:cover": "jasmine --coverage"
   },
   "repository": {
     "type": "git",

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -8,7 +8,7 @@ const AWS = require('aws-sdk');
 // Set the region and endpoint in the config for LocalStack
 AWS.config.update({
   region: 'us-east-1',
-  endpoint: 'http://localhost:4566'
+  endpoint: 'http://127.0.0.1:4566'
 });
 AWS.config.credentials = new AWS.Credentials({
   accessKeyId: 'test',

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -176,7 +176,8 @@ describe("LocalstackPlugin", () => {
       });
       expect(request.called).to.be.true;
       let templateUrl = request.firstCall.args[2].TemplateURL;
-      expect(templateUrl).to.startsWith(`${config.host}`);
+      // url should either start with 'http://localhost' or 'http://127.0.0.1
+      expect(templateUrl).to.satisfy((url) => url.startsWith(`${config.host}`) || url.startsWith('http://127.0.0.1'));
     });
 
     it('should not send validateTemplate calls to localstack', async () => {

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -32,7 +32,7 @@ describe("LocalstackPlugin", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    serverless = new Serverless();
+    serverless = new Serverless({commands: ['deploy'], options: {}});
     awsProvider = new AwsProvider(serverless, {});
     awsConfig = new AWS.Config();
     AWS.config = awsConfig;


### PR DESCRIPTION
CI updates:
* use node 18
* updated deprecated actions
* run tests for severless v2 and v3