### PR TITLE
Strip endpoint hostname trailing slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -385,6 +385,9 @@ class LocalstackPlugin {
     const endpoints = plugin.gatheredData.info.endpoints || [];
     const edgePort = this.getEdgePort();
     endpoints.forEach((entry, idx) => {
+      // Strip trailing slash
+      entry = entry.endsWith("/") ? entry.slice(0, -1) : entry;
+
       // endpoint format for old Serverless versions
       const regex = /[^\s:]*:\/\/([^.]+)\.execute-api[^/]+\/([^/]+)(\/.*)?/g;
       const replace = `http://localhost:${edgePort}/restapis/$1/$2/_user_request_$3`;

--- a/src/index.js
+++ b/src/index.js
@@ -385,9 +385,6 @@ class LocalstackPlugin {
     const endpoints = plugin.gatheredData.info.endpoints || [];
     const edgePort = this.getEdgePort();
     endpoints.forEach((entry, idx) => {
-      // Strip trailing slash
-      entry = entry.endsWith("/") ? entry.slice(0, -1) : entry;
-
       // endpoint format for old Serverless versions
       const regex = /[^\s:]*:\/\/([^.]+)\.execute-api[^/]+\/([^/]+)(\/.*)?/g;
       const replace = `http://localhost:${edgePort}/restapis/$1/$2/_user_request_$3`;
@@ -396,7 +393,7 @@ class LocalstackPlugin {
       //   - https://2e22431f.execute-api.us-east-1.localhost
       //   - https://2e22431f.execute-api.us-east-1.localhost.localstack.cloud
       //   - https://2e22431f.execute-api.us-east-1.amazonaws.com
-      const regex2 = /[^\s:]*:\/\/([^.]+)\.execute-api\.[^/]+(\/([^/]+)(\/.*)?)?/g;
+      const regex2 = /[^\s:]*:\/\/([^.]+)\.execute-api\.[^/]+(([^/]+)(\/.*)?)?\/*$/g;
       const replace2 = `https://$1.execute-api.localhost.localstack.cloud:${edgePort}$2`;
       endpoints[idx] = entry.replace(regex2, replace2);
     });


### PR DESCRIPTION
Not stripping the trailing slash leads to malformed URLs in the output:

Before: https://7d7c2bf6.execute-api.localhost.localstack.cloud:4566//local/task
After: https://7d7c2bf6.execute-api.localhost.localstack.cloud:4566/local/task

The right choice here is dependent on how you define the `path` in `serverless.yml`. Seeing how the [official docs](https://www.serverless.com/framework/docs/providers/aws/events/http-api) for API Gateway v2 add a `/` before the path, I propose that the trailing slash should be stripped here.