### PR TITLE
Unify construction of target endpoint URL, add support for configuring `AWS_ENDPOINT_URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ custom:
 ### Configuration via environment variables
 
 The following environment variables can be configured (taking precedence over the values in `serverless.yml`):
-* `EDGE_PORT`: LocalStack edge port to connect to (default: `4566`)
-* `LOCALSTACK_HOSTNAME`: LocalStack host name to connect to (default: `localhost`)
+* `AWS_ENDPOINT_URL`: LocalStack endpoint URL to connect to (default: `http://localhost:4566`). This is the recommended configuration, and replaces the deprecated config options (`EDGE_PORT`/`LOCALSTACK_HOSTNAME`/`USE_SSL`) below.
+* `EDGE_PORT`: LocalStack edge port to connect to (deprecated; default: `4566`)
+* `LOCALSTACK_HOSTNAME`: LocalStack host name to connect to (deprecated; default: `localhost`)
+* `USE_SSL`: Whether to use SSL/HTTPS when connecting to the LocalStack endpoint (deprecated)
 
 ### Activating the plugin for certain stages
 
@@ -206,6 +208,7 @@ custom:
 
 ## Change Log
 
+* v1.1.2: Unify construction of target endpoint URL, add support for configuring `$AWS_ENDPOINT_URL`
 * v1.1.1: Fix layer deployment if `mountCode` is enabled by always packaging and deploying
 * v1.1.0: Fix SSM environment variables resolving issues with serverless v3, change default for `BUCKET_MARKER_LOCAL` to `hot-reload`
 * v1.0.6: Add `BUCKET_MARKER_LOCAL` configuration for customizing S3 bucket for lambda mount and [Hot Reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading/).

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ custom:
 
 ## Change Log
 
-* v1.1.2: Unify construction of target endpoint URL, add support for configuring `$AWS_ENDPOINT_URL`
+* v1.1.2: Unify construction of target endpoint URL, add support for configuring `AWS_ENDPOINT_URL`
 * v1.1.1: Fix layer deployment if `mountCode` is enabled by always packaging and deploying
 * v1.1.0: Fix SSM environment variables resolving issues with serverless v3, change default for `BUCKET_MARKER_LOCAL` to `hot-reload`
 * v1.0.6: Add `BUCKET_MARKER_LOCAL` configuration for customizing S3 bucket for lambda mount and [Hot Reloading](https://docs.localstack.cloud/user-guide/tools/lambda-tools/hot-reloading/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-localstack",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {
@@ -19,13 +19,13 @@
   "author": "LocalStack Team <info@localstack.cloud>",
   "contributors": [
     "LocalStack Team <info@localstack.cloud>",
-    "temyers",
     "Waldemar Hummer (whummer)",
+    "Ben Simon Hartung (bentsku)",
+    "Joel Scheuner (joe4dev)",
+    "temyers",
     "Justin McCormick <me@justinmccormick.com>",
     "djKooks",
-    "yohei1126",
-    "bentsku",
-    "Joel Scheuner (joe4dev)"
+    "yohei1126"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Unify construction of target endpoint URL, add support for configuring `$AWS_ENDPOINT_URL`. The starting point for this PR was a use case where we want to deploy a [serverless/bref application](https://github.com/mnapoli/test-localstack) against an ephemeral LocalStack instance (running on Namespace). 

It turned out that the current configuration options still use the deprecated config options like `EDGE_PORT`/`USE_SSL`/etc, which we've already removed and replaced with `AWS_ENDPOINT_URL` in other util repos (e.g., `tflocal`, `cdklocal`).

Another issue was that Namespace has some issues routing requests if a request is made with a `Host` header that contains the default HTTPS port 443 (i.e., `Host: my-remote-host:443`). Arguably, we should not be making custom adjustments for a single target platform, but it seems reasonable to replace `https://my-remote-host:443` with `https://my-remote-host`, as this is generally a common practice for addressing HTTPS Web servers.

Note that the entire logic becomes obsolete with the `AWS_ENDPOINT_URL` variable, and we can simplify the logic quite a bit in an upcoming release, once we remove the legacy configuration options. 👍 

Changes:
* add support for setting the target endpoint via `AWS_ENDPOINT_URL`
* update the README with instructions for `AWS_ENDPOINT_URL`, deprecating the old config options
