### PR TITLE
Fix replacing host from environment variable AWS_ENDPOINT_URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -784,7 +784,7 @@ class LocalstackPlugin {
     if (hostname && url.hostname === 'localhost') {
       url.hostname = hostname;
     }
-    return url.href;
+    return url.origin;
   }
 
   log(msg) {


### PR DESCRIPTION
Fixes #237