### PR TITLE
fix autostart and  add support for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ custom:
 ```
 
 ## Change Log
-* v1.2.1: Add docker_compose config and fix autostart when plugin is not active 
+* v1.2.0: Add docker-compose config and fix autostart when plugin is not active 
 * v1.1.3: Fix replacing host from environment variable `AWS_ENDPOINT_URL`
 * v1.1.2: Unify construction of target endpoint URL, add support for configuring `AWS_ENDPOINT_URL`
 * v1.1.1: Fix layer deployment if `mountCode` is enabled by always packaging and deploying

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ custom:
     docker:
       # Enable this flag to run "docker ..." commands as sudo
       sudo: False
+      compose_file: /home/localstack_compose.yml # optional to use docker compose instead of docker or localstack cli
   stages:
     local:
       ...
@@ -207,7 +208,7 @@ custom:
 ```
 
 ## Change Log
-
+* v1.2.1: Add docker_compose config and fix autostart when plugin is not active 
 * v1.1.3: Fix replacing host from environment variable `AWS_ENDPOINT_URL`
 * v1.1.2: Unify construction of target endpoint URL, add support for configuring `AWS_ENDPOINT_URL`
 * v1.1.1: Fix layer deployment if `mountCode` is enabled by always packaging and deploying

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,5 @@
 version: '2'
 services:
-  dev-env:
-    build:
-      context: .
-    working_dir: /app
-    volumes:
-      - .:/app
-      - ~/.aws/:/root/.aws
-      - ~/.gitconfig:/root/.gitconfig
-      - ~/.gitconfig.local:/root/.gitconfig.local
-    environment:
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_PROFILE
-      - AWS_SESSION_TOKEN
-      - AWS_SECURITY_TOKEN
-      - SNYK_TOKEN
-    entrypoint:
-      - /bin/bash
   localstack:
     image: localstack/localstack
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,15 @@
-version: '2'
+version: "3.8"
+
 services:
   localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
     image: localstack/localstack
     ports:
-      - "4567-4582:4567-4582"
-      - "8080:8080"
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
     environment:
-      # Only start a subset of services required for testing.
-      - SERVICES=s3,sns,sqs,apigateway,lambda,dynamodb,dynamodbstreams,cloudformation
-      # - DEBUG=${DEBUG- }
-      # - DATA_DIR=${DATA_DIR- }
-      # - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-      # - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
-      # - DOCKER_HOST=unix:///var/run/docker.sock
-    # volumes:
-    #   - "${TMP_DIR:-/tmp/localstack}:${TMP_DIR:-/tmp/localstack}"
-    #   - "/var/run/docker.sock:/var/run/docker.sock"
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - DEBUG=${DEBUG:-0}
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/example/service/serverless.yml
+++ b/example/service/serverless.yml
@@ -4,11 +4,8 @@ provider:
   name: aws
   profile: ${opt:profile, self:custom.profile}
   stage: ${opt:stage, self:custom.defaultStage}
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   lambdaHashingVersion: '20201221'
-
-plugins:
-  - serverless-localstack
 
 custom:
   defaultStage: local
@@ -16,6 +13,8 @@ custom:
   localstack:
     debug: true
     stages: [local]
+    autostart: true
+    compose_file: /home/cristopher/Projects/serverless-localstack/docker-compose.yml
 
 functions:
   hello:
@@ -23,5 +22,6 @@ functions:
     environment:
       SSM_VAR: ${ssm:abc}
       # CF_VAR: ${cf:def}
-    events:
-      - sns: ${env:EXISTING_TOPIC_ARN}
+
+plugins:
+  - serverless-localstack

--- a/example/service/serverless.yml
+++ b/example/service/serverless.yml
@@ -14,7 +14,7 @@ custom:
     debug: true
     stages: [local]
     autostart: true
-    compose_file: /home/cristopher/Projects/serverless-localstack/docker-compose.yml
+    compose_file: /home/localstack/Projects/serverless-localstack/docker-compose.yml
 
 functions:
   hello:

--- a/example/service/test/serverless.yml
+++ b/example/service/test/serverless.yml
@@ -1,0 +1,2 @@
+component: test
+inputs:

--- a/example/service/test/serverless.yml
+++ b/example/service/test/serverless.yml
@@ -1,2 +1,0 @@
-component: test
-inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-localstack",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.1.3",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.2.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -472,7 +472,7 @@ class LocalstackPlugin {
     }
 
     const startCompose = () => {
-      return exec(`docker-compose -f ${this.config.compose_file} `).then(getContainer)
+      return exec(`docker-compose -f ${this.config.docker.compose_file} `).then(getContainer)
     }
 
     return getContainer().then(
@@ -481,7 +481,7 @@ class LocalstackPlugin {
           return;
         }
 
-        if(this.config.compose_file){
+        if(this.config.docker && this.config.docker.compose_file){
             return startCompose();
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -465,7 +465,7 @@ class LocalstackPlugin {
       env.DEBUG = '1';
       env.LAMBDA_EXECUTOR = env.LAMBDA_EXECUTOR || 'docker';
       env.LAMBDA_REMOTE_DOCKER = env.LAMBDA_REMOTE_DOCKER || '0';
-      env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -d -v ${cwd}:${cwd}`;
+      env.DOCKER_FLAGS = (env.DOCKER_FLAGS || '') + ` -v ${cwd}:${cwd}`;
       env.START_WEB = env.START_WEB || '0';
       const maxBuffer = (+env.EXEC_MAXBUFFER)||50*1000*1000; // 50mb buffer to handle output
       if (this.shouldRunDockerSudo()) {

--- a/src/index.js
+++ b/src/index.js
@@ -472,12 +472,13 @@ class LocalstackPlugin {
         env.DOCKER_CMD = 'sudo docker';
       }
       const options = {env: env, maxBuffer};
-      return exec('localstack start', options).then(getContainer)
+      return exec('localstack start -d', options).then(getContainer)
           .then((containerID) => addNetworks(containerID))
           .then((containerID) => checkStatus(containerID));
     }
 
     const startCompose = () => {
+      this.log('Starting LocalStack using the provided docker-compose file. This can take a while.');
       return exec(`docker-compose -f ${this.config.docker.compose_file} up -d`).then(getContainer)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -413,7 +413,13 @@ class LocalstackPlugin {
     const getContainer = () => {
       return exec('docker ps').then(
         (stdout) => {
-          const exists = stdout.split('\n').filter((line) => line.indexOf('localstack/localstack') >= 0 || line.indexOf('localstack_localstack') >= 0);
+          const exists = stdout.split('\n').filter(
+              (line) => (
+                  line.indexOf('localstack/localstack') >= 0 ||
+                  line.indexOf('localstack/localstack-pro') >= 0 ||
+                  line.indexOf('localstack_localstack') >= 0
+              )
+          );
           if (exists.length) {
             return exists[0].replace('\t', ' ').split(' ')[0];
           }

--- a/src/index.js
+++ b/src/index.js
@@ -482,10 +482,8 @@ class LocalstackPlugin {
         }
 
         if(this.config.compose_file){
-            console.log("Using docker-compose file: " + this.config.compose_file)
             return startCompose();
         }
-        console.log("No docker-compose file: ")
 
         return startContainer();
       }

--- a/src/index.js
+++ b/src/index.js
@@ -406,7 +406,7 @@ class LocalstackPlugin {
    * Start the LocalStack container in Docker, if it is not running yet.
    */
   startLocalStack() {
-    if (!this.config.autostart || !this.isActive()) {
+    if (!(this.config.autostart && this.isActive())) {
       return Promise.resolve();
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -472,7 +472,7 @@ class LocalstackPlugin {
     }
 
     const startCompose = () => {
-      return exec(`docker-compose -f ${this.config.docker.compose_file} `).then(getContainer)
+      return exec(`docker-compose -f ${this.config.docker.compose_file} up -d`).then(getContainer)
     }
 
     return getContainer().then(


### PR DESCRIPTION
This pull request addresses the issue outlined in #153, where LocalStack was inadvertently initiating a container despite the plugin being inactive. 

Additionally, it introduces a new capability (requested in #75): instead of initiating a container through the LocalStack CLI or Docker bin, users can now specify a Docker Compose file to be utilized during the autostart phase. This enhancement provides more flexibility and control over the containerization process.