### PR TITLE
Add new custom-resource patching mechanism for serverless>3.39.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ custom:
 ```
 
 ## Change Log
+* v1.2.1: Fix custom-resource bucket compatibility with serverless >3.39.0, continue improving support for `AWS_ENDPOINT_URL`
 * v1.2.0: Add docker-compose config and fix autostart when plugin is not active 
 * v1.1.3: Fix replacing host from environment variable `AWS_ENDPOINT_URL`
 * v1.1.2: Unify construction of target endpoint URL, add support for configuring `AWS_ENDPOINT_URL`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-localstack",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-localstack",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Motivation

With 3.39.0, serverless migrated their custom resource lambedas to AWS SDK v3, which broke our patching of the `s3ForcePathStyle` into the global AWS config object.

#252 explains the issue in more detail, with impact explained.

We need to adapt our patching mechanism, while still maintaining backwards compatibility with older serverless versions.

## Changes

* Add new sdk-v3 patching mechanism. There is no global config object anymore, so we are replacing the sdk client instantiation.
* Try the old patching first, if line is not found, use the new mechanism. This should maintain backwards compatibility.
