### PR TITLE
prevent mounting of code if the function uses an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ custom:
 ```
 
 ## Change Log
+* v1.3.1: prevent the mounting of code if the Lambda uses an ECR Image
+* v1.3.0: add support for built-in Esbuild in Serverless Framework v4 #267
 * v1.2.1: Fix custom-resource bucket compatibility with serverless >3.39.0, continue improving support for `AWS_ENDPOINT_URL`
 * v1.2.0: Add docker-compose config and fix autostart when plugin is not active 
 * v1.1.3: Fix replacing host from environment variable `AWS_ENDPOINT_URL`

--- a/example/service/serverless.yml
+++ b/example/service/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   profile: ${opt:profile, self:custom.profile}
   stage: ${opt:stage, self:custom.defaultStage}
-  runtime: nodejs16.x
+  runtime: nodejs20.x
   lambdaHashingVersion: '20201221'
 
 custom:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-localstack",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "Connect Serverless to LocalStack!",
   "main": "src/index.js",
   "scripts": {

--- a/spec/helpers/services.js
+++ b/spec/helpers/services.js
@@ -16,7 +16,7 @@ const defaultConfig = {
   service: 'aws-nodejs',
   provider: {
     name: 'aws',
-    runtime: 'nodejs12.x',
+    runtime: 'nodejs20.x',
     lambdaHashingVersion: '20201221',
     environment: {
       LAMBDA_STAGE:

--- a/src/index.js
+++ b/src/index.js
@@ -198,10 +198,10 @@ class LocalstackPlugin {
 
     // Patch plugin methods
     function compileFunction(functionName) {
-      if (!this.shouldMountCode()) {
+      const functionObject = this.serverless.service.getFunction(functionName);
+      if (functionObject.image || !this.shouldMountCode()) {
         return compileFunction._functionOriginal.apply(null, arguments);
       }
-      const functionObject = this.serverless.service.getFunction(functionName);
       functionObject.package = functionObject.package || {};
       functionObject.package.artifact = __filename;
       return compileFunction._functionOriginal


### PR DESCRIPTION
A user reported that the plugin causes LocalStack to fail during a stack update when deploying a Lambda function using an ECR image and mountCode: true is set in the Serverless template's LocalStack configuration.

This PR introduces a validation to disable code mounting when the Lambda function is based on an image, preventing this issue.