### PR TITLE
fix: correct institiation of S3Client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1042,8 +1042,8 @@ class LocalstackPlugin {
         return;
       }
       const data = customResourcesBucketFile.getData().toString();
-      const oldClientCreation = 'S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY });';
-      const newClientCreation = 'S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY, forcePathStyle: true });';
+      const oldClientCreation = 'new S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY })';
+      const newClientCreation = 'new S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY, forcePathStyle: true })';
       if (data.includes(newClientCreation)) {
         // patch already done
         createPatchMarker();


### PR DESCRIPTION
I ran into this issue and am currently doing a patch in my rpeo. 
Just thought you guys might also want this fix as well. Happy to address any problems!

## Problem

  The `patchCustomResourceLambdaS3ForcePathStyle` method fails to inject `forcePathStyle: true` into the Serverless Framework's custom-resources Lambda. This causes `Custom::S3` CloudFormation resources
   to fail during LocalStack deployments with:

  getaddrinfo ENOTFOUND .

  The root cause is a mismatch between the string pattern the plugin searches for and the actual code in `s3/lib/bucket.js` inside `custom-resources.zip`:

  | | Pattern |
  |---|---|
  | **Plugin searches for** | `S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY });` |
  | **Actual code** | `new S3Client({ maxAttempts: MAX_AWS_REQUEST_TRY })` |

  Two differences: missing `new` keyword, and a trailing semicolon that doesn't exist. Because `String.replace()` fails silently when there's no match, the zip is written back unmodified and the
  S3Client never gets `forcePathStyle: true`.

  ## Impact

  Without `forcePathStyle`, the AWS SDK uses virtual-hosted-style S3 addressing (`bucket.hostname:port`), which requires DNS resolution for each bucket name. Inside Docker/LocalStack, these hostnames
  don't resolve — causing all `Custom::S3` resources (e.g. S3 event notifications) to fail during stack creation.

  ## Fix

  Updated the search and replacement strings to match the actual S3Client instantiation code, including the `new` keyword and removing the incorrect semicolon.